### PR TITLE
replaced `init` with `new` for the CLI example

### DIFF
--- a/source/guide/installation.md
+++ b/source/guide/installation.md
@@ -21,7 +21,7 @@ CLI is recommended way of setting up new Strudel project
 
 ```bash
 $ npm install --global strudel-cli
-$ strudel init webpack my-project
+$ strudel new webpack my-project
 $ cd my-project
 $ npm install
 ```


### PR DESCRIPTION
the `init` command doesn't work (maybe it was before I don't know) but `new` is working fine as you can see [here](http://strudeljs.org/guide/usage.html)