### PR TITLE
feat(createDecorator) added a section with createDecorator

### DIFF
--- a/source/api/index.md
+++ b/source/api/index.md
@@ -69,6 +69,37 @@ hideInSidebar: true
   bar
   ```
 
+## Utilities ##
+
+### createDecorator ###
+
+- **Arguments:**
+  - `{*} any (optional)`
+
+- **Details:**
+
+  Creates a custom decorator that can be used for both classes and properties.
+
+- **Usage:**
+
+  ```js
+  const Decorator = createDecorator((component, property) => {
+    /* Decorator logic */
+  });
+
+  const DecoratorWithNoParams = createDecorator((component, property) =>  { 
+    /* Decorator logic */
+  })();
+
+  @Decorator('argument')
+  @Evt('click .example')
+  onClick() {}
+
+  @DecoratorWithNoParams
+  @Evt('click .example-2')
+  onClick2() {}
+  ```
+
 ## Instance Properties / DOM
 
 <blockquote class="alert">Instance properties are injected into `Component` default constructor, so changing the `constructor` for class is forbidden.</blockquote>

--- a/themes/strudel/layout/_partial/api-sidebar.ejs
+++ b/themes/strudel/layout/_partial/api-sidebar.ejs
@@ -17,6 +17,12 @@
     <a href="#El" class="sidebar-nav__link">@El</a>
 </li>
 <li>
+    <h4><a href="#Utilities">Utilities</a></h4>
+</li>
+<li>
+    <a href="#createDecorator" class="sidebar-nav__link">createDecorator</a>
+</li>
+<li>
     <h4><a href="#Instance-Properties-DOM">Instance Properties / DOM</a></h4>
 </li>
 <li>


### PR DESCRIPTION
Added a section about `createDecorator`. If the description (usage, mainly) is too long then I'll change that, just though it's good to provide examples for both types of decorator (with and without params) that can be created with this.